### PR TITLE
Incluindo Frete gratis no ProductDetails e StoreProduvtCard

### DIFF
--- a/src/ProductDetails.js
+++ b/src/ProductDetails.js
@@ -1,12 +1,19 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
+function isFreeShipping(freeShipping) {
+  if (freeShipping) {
+    return (<p data-testid="free-shipping">Frete Gratis</p>);
+  }
+}
+
 function ProductDetails(props, handleCart) {
   const { location: { state: { product } } } = props;
   return (
     <div>
       <p data-testid="product-detail-name">{product.title}</p>
       <p>{product.price}</p>
+      {isFreeShipping(product.shipping.free_shipping)}
       <button
         type="button"
         name="productsOnCart/add"

--- a/src/StoreProductCard.js
+++ b/src/StoreProductCard.js
@@ -2,6 +2,12 @@ import React from 'react';
 import './StoreProductCard.css';
 import { Link } from 'react-router-dom';
 
+function isFreeShipping(freeShipping) {
+  if (freeShipping) {
+    return (<p data-testid="free-shipping">Frete Gratis</p>);
+  }
+}
+
 function StoreProductCard(product, handleCart) {
   const { price, title, thumbnail, id } = product;
   return (
@@ -10,6 +16,7 @@ function StoreProductCard(product, handleCart) {
       <div className="product-data">
         <p className="title">{title}</p>
         <p className="price">{`R$: ${price}`}</p>
+        {isFreeShipping(product.shipping.free_shipping)}
         <div data-testid="product-detail-name">
           <Link
             to={ { pathname: `/product-details/${id}`,


### PR DESCRIPTION
 15. VER QUAIS PRODUTOS TEM FRETE GRÁTIS

**PRIORIDADE 4** - Adicionar indicador de frete grátis à exibição resumida e detalhada do produto (veja os detalhes no card).

- [Tela principal - Exibição detalhada de produto com frete gratis](https://github.com/my-org/my-repo/tree/master/wireframes/card_15.1.png)
- [Tela - Detalhamento de produto com frete gratis](https://github.com/my-org/my-repo/tree/master/wireframes/card_15.2.png)

**Observações técnicas**

As pessoas que vendem no Mercado Livre disponibilizam frete grátis a alguns produtos. Devemos incorporar isso ao e-commerce.

- [x ]  Adicione um elemento que mostre essa informação para cada produto que possua frete grátis na tela de listagem.
  

- [x ]  Adicione o atributo `data-testid` com o valor `free-shipping` em elementos que apresentem essa informação para todos os produtos que possuam frete grátis.

**O que será avaliado:**
- [x]  Exibe corretamente a informação de frete grátis dos produtos